### PR TITLE
Fix coercion bug when an argument type is list and its value is null

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -359,11 +359,10 @@
       (throw-exception "Provided argument value is an array, but the argument is not a list.")
 
       :list
-      (let [fake-argument-def (use-nested-type argument-definition)]
-        ;; if arg-value is nil, should return nil (no coercion is required)
-        (when (some? arg-value)
-          (let [fake-argument-def (use-nested-type argument-definition)]
-            (mapv #(process-literal-argument schema fake-argument-def %) arg-value))))))
+      ;; if arg-value is nil, should return nil (no coercion is required)
+      (when (some? arg-value)
+        (let [fake-argument-def (use-nested-type argument-definition)]
+          (mapv #(process-literal-argument schema fake-argument-def %) arg-value))))))
 
 (defn ^:private decapitalize
   [s]

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -360,7 +360,10 @@
 
       :list
       (let [fake-argument-def (use-nested-type argument-definition)]
-        (mapv #(process-literal-argument schema fake-argument-def %) arg-value)))))
+        ;; if arg-value is nil, should return nil (no coercion is required)
+        (if (nil? arg-value)
+          nil
+          (mapv #(process-literal-argument schema fake-argument-def %) arg-value))))))
 
 (defn ^:private decapitalize
   [s]

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -362,7 +362,8 @@
       (let [fake-argument-def (use-nested-type argument-definition)]
         ;; if arg-value is nil, should return nil (no coercion is required)
         (when (some? arg-value)
-          (mapv #(process-literal-argument schema fake-argument-def %) arg-value))))))
+          (let [fake-argument-def (use-nested-type argument-definition)]
+            (mapv #(process-literal-argument schema fake-argument-def %) arg-value))))))
 
 (defn ^:private decapitalize
   [s]

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -361,8 +361,7 @@
       :list
       (let [fake-argument-def (use-nested-type argument-definition)]
         ;; if arg-value is nil, should return nil (no coercion is required)
-        (if (nil? arg-value)
-          nil
+        (when (some? arg-value)
           (mapv #(process-literal-argument schema fake-argument-def %) arg-value))))))
 
 (defn ^:private decapitalize


### PR DESCRIPTION
Even if the kind of argument definition is `:list`, arg-value of `nil` shouldn't be coerced into `[]`