### PR TITLE
Fixes a runtime error that occurs when deep-merging fragments

### DIFF
--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -409,7 +409,8 @@
 
 (defn- null?
   [v]
-  (= v :com.walmartlabs.lacinia.schema/null))
+  (or (nil? v)
+      (= v :com.walmartlabs.lacinia.schema/null)))
 
 (defn deep-merge
   "Merges two maps together.  Later map override earlier.

--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -407,11 +407,18 @@
            nil
           coll))
 
+(defn- null?
+  [v]
+  (= v :com.walmartlabs.lacinia.schema/null))
+
 (defn deep-merge
   "Merges two maps together.  Later map override earlier.
   If a key is sequential, then each element in the list is merged."
   [left right]
   (cond
+    (or (null? left) (null? right))
+    :com.walmartlabs.lacinia.schema/null
+
     (and (map? left) (map? right))
     (merge-with deep-merge left right)
 


### PR DESCRIPTION
Fixes a bug where inconsistent results occur based on the fragment's declared order.

I fixed a similar issue in #_453, but in that case the fragment was nested, whereas this case is not.

This fails:
```graphql
query MyQuery {
  node(id: "1000") {
    ... on Post {
      id
      ...PostFragment
    }
  }
}

fragment PostFragment on Post {
  author {
    alwaysFail
  }
  ...PostFragment2   # <--
}

fragment PostFragment2 on Post {
  author {
    name
  }
}
```

While this is not:
```graphql
query MyQuery {
  node(id: "1000") {
    ... on Post {
      id
      ...PostFragment
    }
  }
}

fragment PostFragment on Post {
  ...PostFragment2   # <--
  author {
    alwaysFail
  }
}

fragment PostFragment2 on Post {
  author {
    name
  }
}
```


My guess is that `deep-merge` doesn't handle the situation where nil comes in instead of map.
It can be `::null`, or it can actually be `nil`.
It depends on whether the object that catches bubbled-up error is non-null or not.