### PR TITLE
쿼리복잡도 초과시 errors 대신 extensions.warnings 로 리졸빙되도록 수정

### DIFF
--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -83,7 +83,6 @@
           :or {timeout-ms 0
                timeout-error {:message "Query execution timed out."}}} options
          execution-result (execute-parsed-query-async parsed-query variables context options)
-         _ (prn execution-result)
          result (do
                   (resolve/on-deliver! execution-result *result)
                   ;; Block on that deliver, then return the final result.

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -59,13 +59,12 @@
     (seq validation-errors)
     (resolve/resolve-as {:errors validation-errors})
 
-    :let [complexity-warning (when (:max-complexity options)
-                             (complexity-analysis/complexity-analysis prepared options))] 
-
-    :else (executor/execute-query (assoc context constants/parsed-query-key prepared
-                                         :complexity-warning complexity-warning 
+    :else (let [complexity-warning (when (:max-complexity options)
+                                     (complexity-analysis/complexity-analysis prepared options))]
+           (executor/execute-query (assoc context constants/parsed-query-key prepared
+                                         :complexity-warning complexity-warning
                                          ::tracing/validation {:start-offset start-offset
-                                                               :duration (tracing/duration start-nanos)})))))
+                                                               :duration (tracing/duration start-nanos)}))))))
 
 (defn execute-parsed-query
   "Prepares a query, by applying query variables to it, resulting in a prepared

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -59,13 +59,11 @@
     (seq validation-errors)
     (resolve/resolve-as {:errors validation-errors})
 
-    :let [complexity-error (when (:max-complexity options)
+    :let [complexity-warning (when (:max-complexity options)
                              (complexity-analysis/complexity-analysis prepared options))] 
 
     :else (executor/execute-query (assoc context constants/parsed-query-key prepared
-                                         :warnings (if complexity-error
-                                                     (atom [complexity-error])
-                                                     (atom []))
+                                         :complexity-warning complexity-warning 
                                          ::tracing/validation {:start-offset start-offset
                                                                :duration (tracing/duration start-nanos)})))))
 

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -62,9 +62,9 @@
     :else (let [complexity-warning (when (:max-complexity options)
                                      (complexity-analysis/complexity-analysis prepared options))]
            (executor/execute-query (assoc context constants/parsed-query-key prepared
-                                         :complexity-warning complexity-warning
-                                         ::tracing/validation {:start-offset start-offset
-                                                               :duration (tracing/duration start-nanos)}))))))
+                                          :complexity-warning complexity-warning
+                                          ::tracing/validation {:start-offset start-offset
+                                                                :duration (tracing/duration start-nanos)}))))))
 
 (defn execute-parsed-query
   "Prepares a query, by applying query variables to it, resulting in a prepared

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -383,7 +383,7 @@
     (binding [resolve/*callback-executor* executor]
       (let [enabled-selections (remove :disabled? selections)
             *errors (atom [])
-            *warnings (atom [])
+            *warnings (:warnings context)
             *extensions (atom {})
             *resolver-tracing (when (::tracing/enabled? context)
                                 (atom []))

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -379,11 +379,14 @@
   (let [parsed-query (get context constants/parsed-query-key)
         {:keys [selections operation-type ::tracing/timing-start]} parsed-query
         schema (get parsed-query constants/schema-key)
-        ^Executor executor (::schema/executor schema)]
+        ^Executor executor (::schema/executor schema)
+        complexity-warning (:complexity-warning context)]
     (binding [resolve/*callback-executor* executor]
       (let [enabled-selections (remove :disabled? selections)
             *errors (atom [])
-            *warnings (:warnings context)
+            *warnings (if complexity-warning
+                        (atom [complexity-warning])
+                        (atom []))
             *extensions (atom {})
             *resolver-tracing (when (::tracing/enabled? context)
                                 (atom []))

--- a/test/com/walmartlabs/lacinia/complexity_analysis_test.clj
+++ b/test/com/walmartlabs/lacinia/complexity_analysis_test.clj
@@ -41,8 +41,7 @@
 
 (defn ^:private resolve-node
   [_ _ _]
-  {:edges []
-   :pageInfo {}})
+  nil)
 
 (def ^:private schema
   (utils/compile-schema "complexity-analysis-error.edn"
@@ -58,7 +57,8 @@
 (deftest over-complexity-analysis
   (testing "It is possible to calculate the complexity of a query in the Relay connection spec 
             by taking into account both named fragments and inline fragments."
-    (is (= {:errors {:message "Over max complexity! Current number of resources to be queried: 27"}}
+    (is (= {:data {:node nil}
+            :extensions {:warnings [{:message "Over max complexity! Current number of resources to be queried: 27"}]}}
            (q "query ProductDetail($productId: ID){
                node(id: $productId) {
                  ... on Product {
@@ -101,7 +101,8 @@
                }
              }" {:productId "id"}))))
   (testing "If no arguments are passed in the query, the calculation uses the default value defined in the schema."
-    (is (= {:errors {:message "Over max complexity! Current number of resources to be queried: 22"}}
+    (is (= {:data {:node nil}
+            :extensions {:warnings [{:message "Over max complexity! Current number of resources to be queried: 22"}]}}
            (q "query ProductDetail($productId: ID){
                                 node(id: $productId) {
                                   ... on Product {


### PR DESCRIPTION
### AS-IS
<img width="447" alt="image" src="https://github.com/user-attachments/assets/5f2772b5-0637-4cd7-86bf-73b6da1c7a8b">

### TO-BE
<img width="454" alt="image" src="https://github.com/user-attachments/assets/cbe5bded-30d8-474d-83d9-5a22a30fadb8">

기존에는 바로 에러가 발생했던것과 달리 데이터가 정상적으로 리졸빙되며 extensions.warnings에 메세지가 나오도록 수정하였습니다.
datadog에서도 보이게 할 수 있을것 같습니다.

팜모닝 코드에서는 extensions.errors 에 값이 존재하면 slack 알림을 발송하는 식으로 후속작업을 하면 될 것으로 보입니다.

기존 테스트들도 변경사항에 따라 수정해두었습니다.