### PR TITLE
쿼리 복잡도 버그 수정 및 결과 값 수정

### DIFF
--- a/dev-resources/complexity-analysis-error.edn
+++ b/dev-resources/complexity-analysis-error.edn
@@ -84,4 +84,7 @@
  :queries {:node
            {:type :Node
             :args {:id {:type (non-null ID)}}
-            :resolve :resolve-node}}}
+            :resolve :resolve-node}
+           :root
+           {:type :String
+            :resolve :resolve-root}}}

--- a/dev-resources/complexity-analysis-error.edn
+++ b/dev-resources/complexity-analysis-error.edn
@@ -57,7 +57,8 @@
  :Seller
  {:implements [:Node :User]
   :fields {:id {:type (non-null ID)}
-           :name {:type (non-null String)}
+           :name {:type (non-null String)
+                  :resolve :resolve-name}
            :products
            {:type (non-null :ProductConnection)
             :args {:first {:type Int}}

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -21,7 +21,7 @@
             [com.walmartlabs.lacinia.util :refer [as-error-map]]
             [com.walmartlabs.lacinia.resolve :as resolve]
             [com.walmartlabs.lacinia.tracing :as tracing]
-            [com.walmartlabs.lacinia.complexity-analysis :as complexity-analysis])
+            [com.walmartlabs.lacinia.query-analyzer :as query-analyzer])
   (:import (clojure.lang ExceptionInfo)))
 
 (defn ^:private as-errors
@@ -60,9 +60,9 @@
     (resolve/resolve-as {:errors validation-errors})
 
     :else (let [analysis (when (:analyze-query options)
-                           (complexity-analysis/complexity-analysis prepared))]
+                           (query-analyzer/complexity-analysis prepared))]
            (executor/execute-query (assoc context constants/parsed-query-key prepared
-                                          :analysis analysis
+                                          ::query-analyzer/complexity analysis
                                           ::tracing/validation {:start-offset start-offset
                                                                 :duration (tracing/duration start-nanos)}))))))
 

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -57,14 +57,14 @@
     :let [validation-errors (validator/validate prepared)]
 
     (seq validation-errors)
-    (resolve/resolve-as {:errors validation-errors})
+    (resolve/resolve-as {:errors validation-errors}) 
 
-    :else (let [analysis (when (:analyze-query options)
-                           (query-analyzer/complexity-analysis prepared))]
-           (executor/execute-query (assoc context constants/parsed-query-key prepared
-                                          ::query-analyzer/complexity analysis
-                                          ::tracing/validation {:start-offset start-offset
-                                                                :duration (tracing/duration start-nanos)}))))))
+    :else (let [context (assoc context constants/parsed-query-key prepared
+                               ::tracing/validation {:start-offset start-offset
+                                                     :duration (tracing/duration start-nanos)})
+                context' (cond-> context
+                           (:analyze-query options) (assoc ::query-analyzer/complexity (query-analyzer/complexity-analysis prepared)))]
+            (executor/execute-query context')))))
 
 (defn execute-parsed-query
   "Prepares a query, by applying query variables to it, resulting in a prepared

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -59,10 +59,10 @@
     (seq validation-errors)
     (resolve/resolve-as {:errors validation-errors})
 
-    :else (let [complexity-warning (when (:max-complexity options)
-                                     (complexity-analysis/complexity-analysis prepared options))]
+    :else (let [analysis (when (:analyze-query options)
+                           (complexity-analysis/complexity-analysis prepared))]
            (executor/execute-query (assoc context constants/parsed-query-key prepared
-                                          :complexity-warning complexity-warning
+                                          :analysis analysis
                                           ::tracing/validation {:start-offset start-offset
                                                                 :duration (tracing/duration start-nanos)}))))))
 

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -57,12 +57,9 @@
    (seq validation-errors)
    (resolve/resolve-as {:errors validation-errors})
   
-   :else (let [context (assoc context constants/parsed-query-key prepared
-                              ::tracing/validation {:start-offset start-offset
-                                                    :duration (tracing/duration start-nanos)})
-               context' (cond-> context
-                          (::query-analyzer/enable? context) (assoc ::query-analyzer/complexity (query-analyzer/complexity-analysis prepared)))]
-           (executor/execute-query context'))))
+   :else (executor/execute-query (assoc context constants/parsed-query-key prepared
+                                        ::tracing/validation {:start-offset start-offset
+                                                              :duration (tracing/duration start-nanos)}))))
 
 (defn execute-parsed-query
   "Prepares a query, by applying query variables to it, resulting in a prepared

--- a/src/com/walmartlabs/lacinia/complexity_analysis.clj
+++ b/src/com/walmartlabs/lacinia/complexity_analysis.clj
@@ -1,6 +1,5 @@
 (ns com.walmartlabs.lacinia.complexity-analysis
-  (:require
-   [com.walmartlabs.lacinia.selection :as selection]))
+  (:require [com.walmartlabs.lacinia.selection :as selection]))
 
 (defn ^:private list-args? [arguments]
   (some? (or (:first arguments)
@@ -8,11 +7,12 @@
 
 (defn ^:private summarize-selection
   "Recursively summarizes the selection, handling field, inline fragment, and named fragment."
-  [{:keys [arguments selections leaf? field-name fragment-name] :as selection} fragment-map]
+  [{:keys [arguments selections field-name leaf? fragment-name] :as selection} fragment-map]
   (let [selection-kind (selection/selection-kind selection)]
     (cond
       ;; If it's a leaf or `pageInfo`, return nil.
-      (or leaf? (= :pageInfo field-name)) nil
+      (or leaf? (= :pageInfo field-name))
+      nil
 
       ;; If it's a named fragment, look it up in the fragment-map and process its selections.
       (= :named-fragment selection-kind)
@@ -25,7 +25,7 @@
 
       ;; Otherwise, handle a regular field with potential nested selections.
       :else
-      (let [n-nodes (or (-> arguments (select-keys [:first :last]) vals first) 1)] 
+      (let [n-nodes (or (-> arguments (select-keys [:first :last]) vals first) 1)]
         [{:field-name field-name
           :selections (mapcat #(summarize-selection % fragment-map) selections)
           :list-args? (list-args? arguments)

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -27,7 +27,7 @@
    [com.walmartlabs.lacinia.tracing :as tracing]
    [com.walmartlabs.lacinia.constants :as constants]
    [com.walmartlabs.lacinia.selection :as selection]
-   [com.walmartlabs.lacinia.query-analyzer] :as query-analyzer)
+   [com.walmartlabs.lacinia.query-analyzer :as query-analyzer])
   (:import (clojure.lang PersistentQueue)
            (java.util.concurrent Executor)))
 

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -380,14 +380,14 @@
         {:keys [selections operation-type ::tracing/timing-start]} parsed-query
         schema (get parsed-query constants/schema-key)
         ^Executor executor (::schema/executor schema)
-        complexity-warning (:complexity-warning context)]
+        analysis (:analysis context)]
     (binding [resolve/*callback-executor* executor]
       (let [enabled-selections (remove :disabled? selections)
             *errors (atom [])
-            *warnings (if complexity-warning
-                        (atom [complexity-warning])
-                        (atom []))
-            *extensions (atom {})
+            *warnings (atom [])
+            *extensions (if analysis
+                          (atom {:analysis analysis})
+                          (atom {}))
             *resolver-tracing (when (::tracing/enabled? context)
                                 (atom []))
             context' (assoc context constants/schema-key schema)

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -15,18 +15,19 @@
 (ns com.walmartlabs.lacinia.executor
   "Mechanisms for executing parsed queries against compiled schemas."
   (:require
-    [com.walmartlabs.lacinia.internal-utils
-     :refer [cond-let q to-message
-             deep-merge keepv get-nested]]
-    [flatland.ordered.map :refer [ordered-map]]
-    [com.walmartlabs.lacinia.select-utils :as su]
-    [com.walmartlabs.lacinia.resolve-utils :refer [transform-result aggregate-results]]
-    [com.walmartlabs.lacinia.schema :as schema]
-    [com.walmartlabs.lacinia.resolve :as resolve
-     :refer [resolve-as resolve-promise]]
-    [com.walmartlabs.lacinia.tracing :as tracing]
-    [com.walmartlabs.lacinia.constants :as constants]
-    [com.walmartlabs.lacinia.selection :as selection])
+   [com.walmartlabs.lacinia.internal-utils
+    :refer [cond-let q to-message
+            deep-merge keepv get-nested]]
+   [flatland.ordered.map :refer [ordered-map]]
+   [com.walmartlabs.lacinia.select-utils :as su]
+   [com.walmartlabs.lacinia.resolve-utils :refer [transform-result aggregate-results]]
+   [com.walmartlabs.lacinia.schema :as schema]
+   [com.walmartlabs.lacinia.resolve :as resolve
+    :refer [resolve-as resolve-promise]]
+   [com.walmartlabs.lacinia.tracing :as tracing]
+   [com.walmartlabs.lacinia.constants :as constants]
+   [com.walmartlabs.lacinia.selection :as selection]
+   [com.walmartlabs.lacinia.query-analyzer] :as query-analyzer)
   (:import (clojure.lang PersistentQueue)
            (java.util.concurrent Executor)))
 
@@ -380,7 +381,7 @@
         {:keys [selections operation-type ::tracing/timing-start]} parsed-query
         schema (get parsed-query constants/schema-key)
         ^Executor executor (::schema/executor schema)
-        analysis (:analysis context)]
+        analysis (::query-analyzer/complexity context)]
     (binding [resolve/*callback-executor* executor]
       (let [enabled-selections (remove :disabled? selections)
             *errors (atom [])

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -380,14 +380,13 @@
   (let [parsed-query (get context constants/parsed-query-key)
         {:keys [selections operation-type ::tracing/timing-start]} parsed-query
         schema (get parsed-query constants/schema-key)
-        ^Executor executor (::schema/executor schema)
-        analysis (::query-analyzer/complexity context)]
+        ^Executor executor (::schema/executor schema)]
     (binding [resolve/*callback-executor* executor]
       (let [enabled-selections (remove :disabled? selections)
             *errors (atom [])
             *warnings (atom [])
-            *extensions (if analysis
-                          (atom {:analysis analysis})
+            *extensions (if (::query-analyzer/enable? context)
+                          (atom {:analysis (query-analyzer/complexity-analysis parsed-query)})
                           (atom {}))
             *resolver-tracing (when (::tracing/enabled? context)
                                 (atom []))

--- a/src/com/walmartlabs/lacinia/query_analyzer.clj
+++ b/src/com/walmartlabs/lacinia/query_analyzer.clj
@@ -1,4 +1,4 @@
-(ns com.walmartlabs.lacinia.complexity-analysis
+(ns com.walmartlabs.lacinia.query-analyzer
   (:require [com.walmartlabs.lacinia.selection :as selection]))
 
 (defn ^:private list-args? [arguments]

--- a/src/com/walmartlabs/lacinia/query_analyzer.clj
+++ b/src/com/walmartlabs/lacinia/query_analyzer.clj
@@ -44,3 +44,7 @@
         summarized-selections (mapcat #(summarize-selection % fragments) selections)
         complexity (apply + (map calculate-complexity summarized-selections))]
     {:complexity complexity}))
+
+(defn enable-query-analyzer
+  [context]
+  (assoc context ::enable? true))

--- a/test/com/walmartlabs/lacinia/complexity_analysis_test.clj
+++ b/test/com/walmartlabs/lacinia/complexity_analysis_test.clj
@@ -59,7 +59,7 @@
 (defn ^:private q [query variables]
   (utils/simplify (execute schema query variables nil {:analyze-query true})))
 
-(deftest over-complexity-analysis
+(deftest test-complexity-analysis
   (testing "It is possible to calculate the complexity of a query in the Relay connection spec 
             by taking into account both named fragments and inline fragments."
     (is (= {:data {:node nil}
@@ -155,4 +155,4 @@
                }" {:productId "id"})))))
 
 (comment
-  (run-test over-complexity-analysis))
+  (run-test test-complexity-analysis))

--- a/test/com/walmartlabs/lacinia/complexity_analysis_test.clj
+++ b/test/com/walmartlabs/lacinia/complexity_analysis_test.clj
@@ -43,107 +43,116 @@
   [_ _ _]
   nil)
 
+(defn ^:private resolve-name
+  [_ _ _]
+  "name")
+
 (def ^:private schema
   (utils/compile-schema "complexity-analysis-error.edn"
                         {:resolve-products resolve-products
                          :resolve-followings resolve-followings
                          :resolve-reviews resolve-reviews
                          :resolve-likers resolve-likers
-                         :resolve-node resolve-node}))
+                         :resolve-node resolve-node
+                         :resolve-name resolve-name}))
 
 (defn ^:private q [query variables]
-  (utils/simplify (execute schema query variables nil {:max-complexity 10})))
+  (utils/simplify (execute schema query variables nil {:analyze-query true})))
 
 (deftest over-complexity-analysis
   (testing "It is possible to calculate the complexity of a query in the Relay connection spec 
             by taking into account both named fragments and inline fragments."
     (is (= {:data {:node nil}
-            :extensions {:warnings [{:message "Over max complexity! Current number of resources to be queried: 27"}]}}
+            :extensions {:analysis {:complexity 32}}}
            (q "query ProductDetail($productId: ID){
-               node(id: $productId) {
-                 ... on Product {
-                   ...ProductLikersFragment
-                   seller{
-                     id
-                     products(first: 5){
+                 node(id: $productId) {
+                   ... on Product {
+                     ...ProductLikersFragment
+                     seller{
+                       id
+                       products(first: 5){
+                         edges{
+                           node{
+                             id
+                           }
+                         }
+                       }
+                     }
+                     reviews(first: 5){
                        edges{
                          node{
                            id
+                           author{
+                             id
+                             name
+                           }
+                           product{
+                             id
+                           }
                          }
                        }
                      }
                    }
-                   reviews(first: 5){
-                     edges{
-                       node{
+                 }
+               }
+               fragment ProductLikersFragment on Product {
+                 likers(first: 10){
+                   edges{
+                     node{
+                       ... on Seller{
                          id
-                         author{
-                           id
-                         }
+                       }
+                       ... on Buyer{
+                         id
                        }
                      }
                    }
                  }
-               }
-             }
-             fragment ProductLikersFragment on Product {
-               likers(first: 10){
-                 edges{
-                   node{
-                     ... on Seller{
-                       id
-                     }
-                     ... on Buyer{
-                       id
-                     }
-                   }
-                 }
-               }
-             }" {:productId "id"}))))
+               }" {:productId "id"}))))
   (testing "If no arguments are passed in the query, the calculation uses the default value defined in the schema."
     (is (= {:data {:node nil}
-            :extensions {:warnings [{:message "Over max complexity! Current number of resources to be queried: 22"}]}}
+            :extensions {:analysis {:complexity 22}}}
            (q "query ProductDetail($productId: ID){
-                                node(id: $productId) {
-                                  ... on Product {
-                                    ...ProductLikersFragment
-                                    seller{
-                                      id
-                                      products(first: 5){
-                                        edges{
-                                          node{
-                                            id
-                                          }
-                                        }
-                                      }
-                                    }
-                                    reviews(first: 5){
-                                      edges{
-                                        node{
-                                          id
-                                          author{
-                                            id
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                              fragment ProductLikersFragment on Product {
-                                likers{
-                                  edges{
-                                    node{
-                                      ... on Seller{
-                                        id
-                                      }
-                                      ... on Buyer{
-                                        id
-                                      }
-                                    }
-                                  }
-                                }
-                              }" {:productId "id"})))))
+                 node(id: $productId) {
+                   ... on Product {
+                     ...ProductLikersFragment
+                     seller{
+                       id
+                       products(first: 5){
+                         edges{
+                           node{
+                             id
+                           }
+                         }
+                       }
+                     }
+                     reviews(first: 5){
+                       edges{
+                         node{
+                           id
+                           author{
+                             id
+                           }
+                         }
+                       }
+                     }
+                   }
+                 }
+               }
+               fragment ProductLikersFragment on Product {
+                 likers{
+                   edges{
+                     node{
+                       ... on Seller{
+                         id
+                       }
+                       ... on Buyer{
+                         id
+                       }
+                     }
+                   }
+                 }
+               }" {:productId "id"})))))
 
 (comment
   (run-test over-complexity-analysis))

--- a/test/com/walmartlabs/lacinia/complexity_analysis_test.clj
+++ b/test/com/walmartlabs/lacinia/complexity_analysis_test.clj
@@ -47,6 +47,10 @@
   [_ _ _]
   "name")
 
+(defn ^:private resolve-rooot
+  [_ _ _]
+  nil)
+
 (def ^:private schema
   (utils/compile-schema "complexity-analysis-error.edn"
                         {:resolve-products resolve-products
@@ -54,7 +58,8 @@
                          :resolve-reviews resolve-reviews
                          :resolve-likers resolve-likers
                          :resolve-node resolve-node
-                         :resolve-name resolve-name}))
+                         :resolve-name resolve-name
+                         :resolve-root resolve-rooot}))
 
 (defn ^:private q [query variables]
   (utils/simplify (execute schema query variables nil {:analyze-query true})))
@@ -152,7 +157,13 @@
                      }
                    }
                  }
-               }" {:productId "id"})))))
+               }" {:productId "id"}))))
+  (testing "If return type of root query is scala, then complexity is 0"
+    (is (= {:data {:root nil}
+            :extensions {:analysis {:complexity 0}}}
+           (q "query root{
+                 root
+               }" nil)))))
 
 (comment
   (run-test test-complexity-analysis))


### PR DESCRIPTION
root 쿼리에 selections가 없을 경우. 즉 root query의 result가 scala 타입일 경우에 에러가 발생하던 것을 수정하였습니다.

`summarize-selection` 함수에서 selection이 leaf field일 경우에 nil을 반환하게 되는데, `calculate-complexity` 함수에서 nil을 계산하면서 에러가 발생했던 것을 수정하였습니다.

해당 testcase도 추가하였습니다.

추가로 option으로 `max-complexity` 대신 `analyze-query` 를 입력 받고,
`analyze-query`가 true일 경우에 분석결과를 `extensions.analysis` 에 담아서 반환하도록 수정하였습니다.

현재는 analysis 내부에 complexity만 존재하지만 추후 depth나, 호출한 리졸버 갯수 등등을 추가하면 좋을 거 같다고 생각중입니다.
