### PR TITLE
Introspect with specifiedBy

### DIFF
--- a/resources/com/walmartlabs/lacinia/introspection.edn
+++ b/resources/com/walmartlabs/lacinia/introspection.edn
@@ -28,7 +28,9 @@
     :inputFields {:type (list :__InputValue)
                   :resolve :input-fields}
     :ofType {:type :__Type
-             :resolve :of-type}}}
+             :resolve :of-type}
+    :specifiedByUrl {:type String
+                     :resolve :specified-by-url}}}
 
   :__Field
   {:fields

--- a/src/com/walmartlabs/lacinia/introspection.clj
+++ b/src/com/walmartlabs/lacinia/introspection.clj
@@ -280,6 +280,11 @@
                       (::type-map input-value)
                       (::default-value input-value)))
 
+(defn ^:private resolve-specified-by-url
+  [_ _ {:keys [::category ::type-def] :as _value}]
+  (when (= :scalar category)
+    (:specified-by type-def)))
+
 (defn introspection-schema
   "Builds an returns the introspection schema, which can be merged into the user schema."
   []
@@ -296,4 +301,5 @@
                               :interfaces resolve-interfaces
                               :of-type resolve-of-type
                               :possible-types resolve-possible-types
-                              :default-value default-value})))
+                              :default-value default-value
+                              :specified-by-url resolve-specified-by-url})))

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -629,6 +629,7 @@
 (s/def ::fn-map (s/map-of simple-keyword? ::field-fn))
 (s/def ::parse ::schema/parse-or-serialize-fn)
 (s/def ::serialize ::schema/parse-or-serialize-fn)
+(s/def ::specified-by string?)
 (s/def ::scalar-def (s/keys :req-un [::parse ::serialize]
                             :opt-un [::description ::specified-by]))
 (s/def ::description string?)

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -630,7 +630,7 @@
 (s/def ::parse ::schema/parse-or-serialize-fn)
 (s/def ::serialize ::schema/parse-or-serialize-fn)
 (s/def ::scalar-def (s/keys :req-un [::parse ::serialize]
-                            :opt-un [::description]))
+                            :opt-un [::description ::specified-by]))
 (s/def ::description string?)
 
 (s/def ::documentation (s/map-of keyword? string?))

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -38,7 +38,6 @@
     [clojure.pprint :as pprint]
     [com.walmartlabs.lacinia.selection :as selection])
   (:import
-   (java.net URL)
    (clojure.lang IObj PersistentQueue)
    (java.io Writer)
    (java.util.concurrent Executor ThreadPoolExecutor TimeUnit LinkedBlockingQueue ThreadFactory)))
@@ -290,11 +289,11 @@
   ([message data]
    (merge {:message message} data)))
 
-(defn url?
-  [url]
+(defn valid-url? [s]
   (try
-    (URL. url)
-    true
+    (let [uri (java.net.URI. s)]
+      (.toURL uri)
+      true)
     (catch Exception _ false)))
 
 ;;-------------------------------------------------------------------------------
@@ -405,7 +404,7 @@
                            :var var?))
 (s/def ::parse ::parse-or-serialize-fn)
 (s/def ::serialize ::parse-or-serialize-fn)
-(s/def ::specified-by url?)
+(s/def ::specified-by valid-url?)
 (s/def ::scalar (s/keys :opt-un [::description
                                  ::directives
                                  ::specified-by]

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -38,9 +38,10 @@
     [clojure.pprint :as pprint]
     [com.walmartlabs.lacinia.selection :as selection])
   (:import
-    (clojure.lang IObj PersistentQueue)
-    (java.io Writer)
-    (java.util.concurrent Executor ThreadPoolExecutor TimeUnit LinkedBlockingQueue ThreadFactory)))
+   (java.net URL)
+   (clojure.lang IObj PersistentQueue)
+   (java.io Writer)
+   (java.util.concurrent Executor ThreadPoolExecutor TimeUnit LinkedBlockingQueue ThreadFactory)))
 
 ;; When using Clojure 1.8, the dependency on clojure-future-spec must be included,
 ;; and this code will trigger
@@ -289,6 +290,13 @@
   ([message data]
    (merge {:message message} data)))
 
+(defn url?
+  [url]
+  (try
+    (URL. url)
+    true
+    (catch Exception _ false)))
+
 ;;-------------------------------------------------------------------------------
 ;; ## Validations
 
@@ -397,6 +405,7 @@
                            :var var?))
 (s/def ::parse ::parse-or-serialize-fn)
 (s/def ::serialize ::parse-or-serialize-fn)
+(s/def ::specified-by url?)
 (s/def ::scalar (s/keys :opt-un [::description
                                  ::directives
                                  ::specified-by]

--- a/test/com/walmartlabs/introspection_test.clj
+++ b/test/com/walmartlabs/introspection_test.clj
@@ -1505,3 +1505,23 @@
                                    :line 1}]
                       :message "Cannot query field `__type' on type `Query'."}]}
            (execute schema q)))))
+
+(def ^:private specified-by-url-query 
+  "{
+     __type(name: \"DateTime\") {
+       name
+       kind
+       specifiedByUrl
+     }
+   }")
+
+(deftest scalar-specified-by-url
+  (let [schema (schema/compile {:scalars {:DateTime {:parse identity
+                                                     :serialize identity
+                                                     :specified-by "https://scalars.graphql.org/andimarek/date-time.html"}}})]
+    (is (= {:data
+            {:__type
+             {:kind :SCALAR
+              :name "DateTime"
+              :specifiedByUrl "https://scalars.graphql.org/andimarek/date-time.html"}}}
+           (utils/execute schema specified-by-url-query)))))


### PR DESCRIPTION
According to [GraphQL Spec October2021](https://spec.graphql.org/October2021/#sec-Scalars.Custom-Scalars)

`When defining a custom scalar, GraphQL services should provide a [scalar specification URL](https://spec.graphql.org/October2021/#scalar-specification-url) via the @specifiedBy directive or the specifiedByURL introspection field.`

### In schema
```
type __Type {
  ...
  # may be non-null for custom SCALAR, otherwise null.
  specifiedByURL: String
}
```

### Example query and result
If your service has a custom scalar called :Email and has defined :specified-by, such as ...
```
{:scalars {:Email {:parse parser-fn
                   :serialize serialize-fn
                   :specified-by "https://datatracker.ietf.org/doc/html/rfc5322"}}
```
![image](https://github.com/user-attachments/assets/264c02d8-0262-43f0-93bb-c348f351ccdf)


